### PR TITLE
fixed exception when sending object over rtmp and there was no serialize...

### DIFF
--- a/rtmp-sharp/IO/AmfWriter.cs
+++ b/rtmp-sharp/IO/AmfWriter.cs
@@ -959,7 +959,7 @@ namespace RtmpSharp.IO
                 WriteAmf3InlineHeader(header);
                 WriteAmf3Utf(classDescription.Name);
                 foreach (var member in classDescription.Members)
-                    WriteAmf3Utf(member.SerializedName);
+                    WriteAmf3Utf(member.SerializedName ?? member.Name);
 
                 // write object
                 if (classDescription.IsExternalizable)


### PR DESCRIPTION
If an object is sent over with InvokeAsync and the class does not contain SerializedName for every property, then rtmp-sharp would exception with an argument error as it tries to write a null value for the property name. Now it checks if SerializedName is null and if it is, it resort to the property name; otherwise it'll continue using the serialized name.
