### PR TITLE
Fixed new space start position.

### DIFF
--- a/src/_Sky/Hina/Space.cs
+++ b/src/_Sky/Hina/Space.cs
@@ -43,7 +43,7 @@ namespace Hina
                 throw OutOfRangeException();
 
             this.array  = array;
-            this.offset = 0;
+            this.offset = start;
             this.length = arrayLength - start;
         }
 


### PR DESCRIPTION
After failing to ReadSingleFrame, the next message would override previous available data during ReadFromStreamAsync.